### PR TITLE
Update incorrect version in description

### DIFF
--- a/example-scripts/exitStatusParentheses.ps1
+++ b/example-scripts/exitStatusParentheses.ps1
@@ -6,7 +6,7 @@ OutputText @'
 In PowerShell, the `$?` variable represents the exit status of the previous
 command. If it's true, the command succeeded. If it's false, the command
 failed. However, you need to be careful if using the variable, since enclosing
-a command in parentheses can reset `$?` to true in PowerShell 5 and earlier.
+a command in parentheses can reset `$?` to true in PowerShell 6 and earlier.
 '@
 
 OutputCode {


### PR DESCRIPTION
The problem of `$?` being reset to true after parentheses occurs in
PowerShell version 6 and earlier, not 5 and earlier.