### PR TITLE
Add support for testing on PowerShell 2

### DIFF
--- a/docgen/OutputCmdlets.psm1
+++ b/docgen/OutputCmdlets.psm1
@@ -64,8 +64,7 @@ function OutputCode {
         Write-Host "Running $exe"
 
         $commandOutput = InvokeExe $exe $Code.ToString()
-        $stringCommandOutput = $commandOutput -join "`n"
-        $formattedCommandOutput = "<pre class=`"output-text`">" + $stringCommandOutput + "</pre>"
+        $formattedCommandOutput = "<pre class=`"output-text`">" + $commandOutput + "</pre>"
 
         if (-not $outputToVersionMap.ContainsKey($formattedCommandOutput)) {
             $outputToVersionMap[$formattedCommandOutput] = @()

--- a/example-scripts/writeErrorFunction.ps1
+++ b/example-scripts/writeErrorFunction.ps1
@@ -6,6 +6,11 @@ OutputText @'
 When `$ErrorActionPreference` is `Stop`, `$PSCmdlet.WriteError` exits the
 current advanced function and throws. However, the exception it throws is not
 catchable from within the advanced function.
+
+It's worth noting that in PowerShell 2, the exception is caught both inside the
+function and outside the function. Inside the function we catch a "The pipeline
+has been stopped." error, and then continue execution within the function. When
+the function exits, we then throw the original exception.
 '@
 
 OutputCode {
@@ -17,7 +22,7 @@ OutputCode {
         try {
             $PSCmdlet.WriteError((NewErrorRecord "error in try"))
         } catch {
-            Write-Output "caught inside the cmdlet: $_"
+            Write-Output "caught inside the function: $_"
         }
 
         Write-Output "after the try-catch"
@@ -26,7 +31,7 @@ OutputCode {
     try {
         TestWriteErrorFunction
     } catch {
-        Write-Output "caught outside the cmdlet: $_"
+        Write-Output "caught outside the function: $_"
     }
 }
 
@@ -44,7 +49,7 @@ OutputCode {
         try {
             Write-Error "error in try"
         } catch {
-            Write-Output "caught inside the cmdlet: $_"
+            Write-Output "caught inside the function: $_"
         }
 
         Write-Output "after the try-catch"
@@ -57,7 +62,7 @@ OutputCode {
         try {
             Write-Error "error in try"
         } catch {
-            Write-Output "caught inside the cmdlet: $_"
+            Write-Output "caught inside the function: $_"
         }
 
         Write-Output "after the try-catch"
@@ -67,7 +72,7 @@ OutputCode {
     try {
         TestWriteErrorCmdletAdvanced
     } catch {
-        Write-Output "caught outside the cmdlet: $_"
+        Write-Output "caught outside the function: $_"
     }
 
     Write-Output ""
@@ -76,7 +81,7 @@ OutputCode {
     try {
         TestWriteErrorCmdletBasic
     } catch {
-        Write-Output "caught outside the cmdlet: $_"
+        Write-Output "caught outside the function: $_"
     }
 }
 

--- a/util/util.psm1
+++ b/util/util.psm1
@@ -5,12 +5,25 @@ function NewErrorRecord {
         [String] $Text
     )
 
-    return [System.Management.Automation.ErrorRecord]::new(
-        # The underlying .NET exception: if you pass a string, as here, PS
-        # creates a [System.Exception] instance.
-        $Text,
-        $null, # error ID
-        [System.Management.Automation.ErrorCategory]::InvalidData, # error category
-        $null) # offending object
+    if ($PSVersionTable.PSVersion.ToString() -eq "2.0") {
+        # PowerShell version 2 doesn't support the `new` syntax for
+        # constructors, so use `New-Object` instead. I could have also just
+        # always used `New-Object` since it works with both, but ¯\_(ツ)_/¯.
+        return New-Object System.Management.Automation.ErrorRecord -Args @(
+            # The underlying .NET exception: if you pass a string, as here, PS
+            # creates a [System.Exception] instance.
+            $Text,
+            $null, # error ID
+            [System.Management.Automation.ErrorCategory]::InvalidData, # error category
+            $null) # offending object
+    } else {
+        return [System.Management.Automation.ErrorRecord]::new(
+            # The underlying .NET exception: if you pass a string, as here, PS
+            # creates a [System.Exception] instance.
+            $Text,
+            $null, # error ID
+            [System.Management.Automation.ErrorCategory]::InvalidData, # error category
+            $null) # offending object
+    }
 }
 Export-ModuleMember -Function NewErrorRecord


### PR DESCRIPTION
Turns out there's a Windows PowerShell 2.0 Engine
(https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-the-windows-powershell-2.0-engine).
Other versions don't seem to be available, but running in PowerShell 2.0
can produce some interesting results.

I've updated the `WriteError` function example to explain version 2's
behavior. I also updated the word "cmdlet" in that example to
"function", since PowerShell advanced functions are not technically
cmdlets.

Fixes #5