### PR TITLE
Follow some better best practices

### DIFF
--- a/buildSite.ps1
+++ b/buildSite.ps1
@@ -1,12 +1,18 @@
+using namespace System.IO
+using namespace System.Management.Automation
+
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = "Stop"
+
 Import-Module $PSScriptRoot\docgen -Force
 
-$pageModules = Get-ChildItem $PSScriptRoot "example-pages\*.psm1"
-$scriptHtml = $pageModules | ForEach-Object { OutputPage $_ }
+[FileInfo[]] $pageModules = Get-ChildItem $PSScriptRoot "example-pages\*.psm1"
+[String[]] $scriptHtml = $pageModules | ForEach-Object { OutputPage $_ }
 
-$versionsTested = GetPowerShellExesToTest | ForEach-Object { GetExeVersion $_ } | Sort-Object
-$versionsTestedHtml = ($versionsTested | ForEach-Object { "<span class=`"tested-version`">$_</span>" }) -join ", "
+[SemanticVersion[]] $versionsTested = GetPowerShellExesToTest | ForEach-Object { GetExeVersion $_ } | Sort-Object
+[String] $versionsTestedHtml = ($versionsTested | ForEach-Object { "<span class=`"tested-version`">$_</span>" }) -join ", "
 
-$htmlPrefix = @"
+[String] $htmlPrefix = @"
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
@@ -28,19 +34,18 @@ $htmlPrefix = @"
             <main>
 "@
 
-$htmlSuffix = @'
+[String] $htmlSuffix = @'
             </main>
         </div>
     </body>
 </html>
 '@
 
-$html = "$htmlPrefix$scriptHtml$htmlSuffix"
+[String] $html = "$htmlPrefix$scriptHtml$htmlSuffix"
 
-$webrootPath = "$PSScriptRoot\webroot"
-if (-not (Test-Path $webrootPath)) {
-    mkdir $webrootPath
-}
+[String] $webrootPath = "$PSScriptRoot\webroot"
+Remove-Item $webrootPath -Recurse -Force -ErrorAction "SilentlyContinue"
+mkdir $webrootPath > $null
 
 Set-Content $webrootPath\index.html $html
 Copy-Item $PSScriptRoot\style.css $webrootPath

--- a/docgen/ExesToTest.psm1
+++ b/docgen/ExesToTest.psm1
@@ -1,6 +1,10 @@
+using namespace System.IO
 using namespace System.Management.Automation
 
-$windowsPowershellExes = @(
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = "Stop"
+
+[String[]] $windowsPowershellExes = @(
     "powershell -Version 2",
     "powershell -Version 5.1"
 )
@@ -10,9 +14,9 @@ function GetPowerShellExesToTest {
     [OutputType([String[]])]
     param()
 
-    $packageDir = "$PSScriptRoot\..\pwsh-packages"
-    $packages = Get-ChildItem $packageDir
-    $packageExes = $packages | ForEach-Object { "$($_.FullName)\pwsh.exe" }
+    [String] $packageDir = "$PSScriptRoot\..\pwsh-packages"
+    [DirectoryInfo[]] $packages = Get-ChildItem $packageDir
+    [String[]] $packageExes = $packages | ForEach-Object { "$($_.FullName)\pwsh.exe" }
 
     return $windowsPowershellExes + $packageExes
 }
@@ -24,10 +28,10 @@ function RemoveBom {
         [String] $InputString
     )
 
-    $bomString = [System.Text.Encoding]::UTF8.GetString(@(239, 187, 191))
+    [String] $bomString = [System.Text.Encoding]::UTF8.GetString(@(239, 187, 191))
 
     # Remove the BOM from the beginning of the string.
-    $InputString -replace "^$bomString", ""
+    return $InputString -replace "^$bomString", ""
 }
 
 function GetExeVersion {
@@ -37,19 +41,19 @@ function GetExeVersion {
         [String] $Exe
     )
 
-    $rawVersionString = Invoke-Expression "$Exe -NoProfile -c `"```$PSVersionTable.PSVersion.ToString()`""
+    [String] $rawVersionString = Invoke-Expression "$Exe -NoProfile -c `"```$PSVersionTable.PSVersion.ToString()`""
 
     # Sometimes with PowerShell v2 there's a BOM at the beginning of the output string.
-    $versionString = RemoveBom $rawVersionString
+    [String] $versionString = RemoveBom $rawVersionString
 
     if ($Exe -in $windowsPowershellExes) {
-        $legacyVersion = [Version]::new($versionString)
-        $version = [SemanticVersion]::new(`
+        [Version] $legacyVersion = [Version]::new($versionString)
+        [SemanticVersion] $version = [SemanticVersion]::new(`
             $legacyVersion.Major,`
             $legacyVersion.Minor,`
             $legacyVersion.Revision -ge 0 ? $legacyVersion.Revision : 0)
     } else {
-        $version = [SemanticVersion]::new($versionString)
+        [SemanticVersion] $version = [SemanticVersion]::new($versionString)
     }
 
     return $version
@@ -63,11 +67,11 @@ function InvokeExe {
         [String] $Expr
     )
 
-    $tempScript = New-Item "Temp:\$(New-Guid).ps1"
+    [FileInfo] $tempScript = New-Item "Temp:\$(New-Guid).ps1"
     try {
-        $header = "Import-Module -Force $PSScriptRoot\..\util"
+        [String] $header = "Import-Module -Force $PSScriptRoot\..\util"
         Set-Content $tempScript.FullName "$header; $Expr"
-        $result = Invoke-Expression "$Exe -NoProfile -File $tempScript"
+        [String[]] $result = Invoke-Expression "$Exe -NoProfile -File $tempScript"
 
         # Sometimes with PowerShell v2 there's a BOM at the beginning of the
         # output string.

--- a/docgen/docgen.psm1
+++ b/docgen/docgen.psm1
@@ -1,0 +1,2 @@
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = "Stop"

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -5,14 +5,14 @@ try {
     # during development. Import-Module -Force doesn't work with classes :(
     pwsh -c {
         Import-Module pester -Force
-        $config = [PesterConfiguration]::Default
+        [PesterConfiguration] $config = [PesterConfiguration]::Default
 
         # Exit with non-zero exit code when the test run fails.
         $config.Run.Exit = $true
 
         Invoke-Pester -Configuration $config
     }
-    $exitCode = $LASTEXITCODE
+    [Int32] $exitCode = $LASTEXITCODE
 } finally {
     Pop-Location
 }

--- a/tests/docgen.Tests.ps1
+++ b/tests/docgen.Tests.ps1
@@ -12,7 +12,7 @@ function global:V {
     $VersionStrings | ForEach-Object { [SemanticVersion]::new($_) }
 }
 
-$global:allVersions = (V `
+[SemanticVersion[]] $global:allVersions = (V `
     0.1.0,`
     0.2.0,`
     0.3.0,`
@@ -48,13 +48,13 @@ Describe "VersionTree" {
         }
 
         It "can add a single version" {
-            $tree = [VersionTree]::new()
+            [VersionTree] $tree = [VersionTree]::new()
             $tree.Add((V 1.2.3))
             $tree.ToString() | Should -Be "(root (1 (2 3)))"
         }
 
         It "can add multiple versions" {
-            $tree = [VersionTree]::new()
+            [VersionTree] $tree = [VersionTree]::new()
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }
@@ -63,7 +63,7 @@ Describe "VersionTree" {
         }
 
         It "can mark a single version" {
-            $tree = [VersionTree]::new()
+            [VersionTree] $tree = [VersionTree]::new()
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }
@@ -74,7 +74,7 @@ Describe "VersionTree" {
         }
 
         It "can mark multiple versions" {
-            $tree = [VersionTree]::new()
+            [VersionTree] $tree = [VersionTree]::new()
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }

--- a/util/util.psm1
+++ b/util/util.psm1
@@ -1,3 +1,6 @@
+Set-StrictMode -Version Latest
+$script:ErrorActionPreference = "Stop"
+
 function NewErrorRecord {
     [CmdletBinding()]
     [OutputType([System.Management.Automation.ErrorRecord])]


### PR DESCRIPTION
The changes are as follows:

* Set `ErrorActionPreference` to `Stop` in every file
* Use `Set-StrictMode -Version Latest` in every file
* Explicitly declare the type of every variable
  * I'm not sure if this is actually best practice, but I get so many
    confusing bugs due to PowerShell's aggressive implicit casting and
    general willingness to allow incorrect types wherever. It's nice to
    at least know just by looking at the code what type a variable is.

This change also clears the webroot directory on every build to make
sure leftover files can't affect the site during testing.