### PR TITLE
Simplify generic type literals

### DIFF
--- a/docgen/GeneralizeVersions.psm1
+++ b/docgen/GeneralizeVersions.psm1
@@ -62,10 +62,10 @@ class VersionNode {
         $this.IsLeafInSubset = $false
     }
 
-    [Void] AddNodesBelow([Tuple`2[[Object], [String]][]] $Values) {
+    [Void] AddNodesBelow([Tuple[Object, String][]] $Values) {
         if ($Values.Count -gt 0) {
-            [Tuple`2[[Object], [String]]] $first = $Values[0]
-            [Tuple`2[[Object], [String]][]] $rest = GetRest $Values
+            [Tuple[Object, String]] $first = $Values[0]
+            [Tuple[Object, String][]] $rest = GetRest $Values
 
             foreach ($child in $this.Children) {
                 if (ValuesEqual $child.Value $first.Item1) {
@@ -94,7 +94,7 @@ class VersionNode {
         }
     }
 
-    [Tuple`2[[String[]], [Boolean]]] Generalize() {
+    [Tuple[[String[]], Boolean]] Generalize() {
         if ($this.Children.Count -eq 0) {
             if ($this.IsLeafInSubset) {
                 return [Tuple]::Create([String[]] @($this.Value.ToString()), $true)
@@ -106,7 +106,7 @@ class VersionNode {
             [Byte] $numChildrenFullyCovered = 0
 
             foreach ($child in $this.Children) {
-                [Tuple`2[[String[]], [Boolean]]] $result = $child.Generalize()
+                [Tuple[[String[]], Boolean]] $result = $child.Generalize()
 
                 if ($null -ne $result.Item1 -and $result.Item1.Count -gt 0) {
                     $childResults += $result.Item1
@@ -150,7 +150,7 @@ class VersionTree {
     }
 
     [Void] Add([SemanticVersion] $Version) {
-        [Tuple`2[[Object], [String]][]] $nodeValues = @(
+        [Tuple[Object, String][]] $nodeValues = @(
             [Tuple]::Create([Object] $Version.Major, "x"),
             [Tuple]::Create([Object] $Version.Minor, "y"),
             [Tuple]::Create([Object] $Version.Patch, "")

--- a/docgen/OutputCmdlets.psm1
+++ b/docgen/OutputCmdlets.psm1
@@ -93,7 +93,7 @@ function OutputCode {
 
     # Create a map of output string to list of versions. This lets us group
     # versions by what their output is.
-    [Dictionary`2[[String], [SemanticVersion[]]]] $outputToVersionMap = [Dictionary`2[[String], [SemanticVersion[]]]]::new()
+    [Dictionary[String, SemanticVersion[]]] $outputToVersionMap = [Dictionary[String, SemanticVersion[]]]::new()
     [SemanticVersion[]] $allVersions = @()
     foreach ($exe in $exesToTest) {
         Write-Host "Running $exe"
@@ -112,7 +112,7 @@ function OutputCode {
 
     # Now create a map from version string to corresponding output. This lets
     # us sort the version strings without mismatching them with their outputs.
-    [Dictionary`2[[String], [String]]] $versionStringToOutputMap = [Dictionary`2[[String], [String]]]::new()
+    [Dictionary[String, String]] $versionStringToOutputMap = [Dictionary[String, String]]::new()
     foreach ($output in $outputToVersionMap.Keys) {
         [String[]] $generalizedVersions = GeneralizeVersions $allVersions $outputToVersionMap[$output] | Sort-Object
         $versionStringToOutputMap["<th>$($generalizedVersions -join ", ")</th>"] = $output

--- a/downloadPwshPackages.ps1
+++ b/downloadPwshPackages.ps1
@@ -68,7 +68,7 @@ function WriteRateLimit {
 
 function GetAllReleaseUrls {
     [CmdletBinding()]
-    [OutputType([Tuple`3[[String], [String], [Int64]][]])]
+    [OutputType([Tuple[String, String, Int64][]])]
     param()
 
     [String] $url = "https://api.github.com/repos/PowerShell/PowerShell/releases"
@@ -86,7 +86,7 @@ function GetAllReleaseUrls {
         Where-Object { [SemanticVersion] $v = GetVersionFromRelease $_; $v -ge [SemanticVersion]::new(6) } |`
         Where-Object { Invoke-Command $ReleaseFilter -Args $releases, $_ }
 
-    [Tuple`3[[String], [String], [Int64]][]] $assetUrls = $filteredReleases | ForEach-Object {
+    [Tuple[String, String, Int64][]] $assetUrls = $filteredReleases | ForEach-Object {
         [PSCustomObject] $release = $_
         [PSCustomObject] $asset = ($release.assets | Where-Object { $_.name -match "-win-x64.zip`$" })[0] # there should only be one
         return [Tuple]::Create($release.tag_name, $asset.url, $asset.size)
@@ -115,7 +115,7 @@ function DownloadUrls {
     [CmdletBinding()]
     [OutputType([Void])]
     param(
-        [Tuple`3[[String], [String], [Int64]][]] $UrlPairs
+        [Tuple[String, String, Int64][]] $UrlPairs
     )
 
     [String] $packageDir = "$PSScriptRoot\pwsh-packages"
@@ -146,5 +146,5 @@ function DownloadUrls {
     }
 }
 
-[Tuple`3[[String], [String], [Int64]][]] $urls = GetAllReleaseUrls
+[Tuple[String, String, Int64][]] $urls = GetAllReleaseUrls
 DownloadUrls $urls


### PR DESCRIPTION
This means getting rid of the `2, `3, etc. bit, as well as not
surrounding the type parameters in brackets unless they're arrays.