### PR TITLE
Properly handle visibility of functions in docgen module

### DIFF
--- a/docgen/ExesToTest.ps1
+++ b/docgen/ExesToTest.ps1
@@ -1,10 +1,7 @@
 using namespace System.IO
 using namespace System.Management.Automation
 
-Set-StrictMode -Version Latest
-$script:ErrorActionPreference = "Stop"
-
-[String[]] $windowsPowershellExes = @(
+[String[]] $script:windowsPowershellExes = @(
     "powershell -Version 2",
     "powershell -Version 5.1"
 )

--- a/docgen/GeneralizeVersions.ps1
+++ b/docgen/GeneralizeVersions.ps1
@@ -1,8 +1,5 @@
 using namespace System.Management.Automation
 
-Set-StrictMode -Version Latest
-$script:ErrorActionPreference = "Stop"
-
 [Object] $script:RootValue = ""
 
 function ValuesEqual {

--- a/docgen/OutputCmdlets.ps1
+++ b/docgen/OutputCmdlets.ps1
@@ -2,9 +2,6 @@ using namespace System.Collections.Generic
 using namespace System.IO
 using namespace System.Management.Automation
 
-Set-StrictMode -Version Latest
-$script:ErrorActionPreference = "Stop"
-
 function GetIndent {
     [CmdletBinding()]
     [OutputType([Byte])]

--- a/docgen/docgen.psd1
+++ b/docgen/docgen.psd1
@@ -7,11 +7,12 @@ Description = "Helpers for generating pwsh-live-doc HTML"
 PowerShellVersion = "7.0"
 
 NestedModules = @(
-    "OutputCmdlets.psm1",
-    "GeneralizeVersions.psm1",
-    "ExesToTest.psm1")
+    "OutputCmdlets.ps1",
+    "GeneralizeVersions.ps1",
+    "ExesToTest.ps1")
 
-CmdletsToExport = @(
+FunctionsToExport = @(
+    "OutputPage",
     "OutputText",
     "OutputCode",
     "GetPowerShellExesToTest",


### PR DESCRIPTION
The main change here was to change "CmdletsToExport" to
"FunctionsToExport". I must have copy pasted from an old project that
used the wrong one and never fixed it.

Also, turns out if your "NestedModules" key has actual `.psm1` files in
it, those nested modules are only available in the entry point into the
module. This means that if you call `OutputCode`, say, and it calls
`RunPowerShellExe`, only functions inside `OutputCmdlets.psm1` (and
public functions of docgen) will be available from within
`RunPowerShellExe`. The fix was to switch back to how I used to do
things and use `.ps1` files rather than `.psm1`. Then any module-level
configuration can be done in `docgen.psm1`, and it will apply to all
sourced `.ps1`s.