### PR TITLE
Implement deploy to Netlify

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -36,7 +36,6 @@ jobs:
   deploy:
     runs-on: windows-latest
     needs: build
-    if: ${{ github.event_name == 'push' }}
     steps:
     - uses: actions/checkout@v2
 
@@ -46,8 +45,12 @@ jobs:
         name: site
         path: .\webroot\
 
-    - name: Deploy the docs to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Deploy the docs to Netlify
+      uses: nwtgck/actions-netlify@v1.1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: .\webroot\
+        publish-dir: .\webroot\
+        production-branch: master
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
This will replace deploy to GitHub Pages, and the old GitHub Pages URL
will redirect to the Netlify site.

Netlify offers some advantages, the biggest being we can use a custom
domain that doesn't still need a `/pwsh-live-doc/` path after it. Also,
it'll be nice to deploy to a site that's fully owned by this project,
rather than a subdirectory in a larger site.

Links #2