### PR TITLE
Allow example pages to include subheadings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ function.
 Helper functions are available automatically in each page module's RunPage
 function.
 
+#### OutputHeading
+
+This function takes a heading level (starting at 1) and content for the
+heading, and outputs a heading element.
+
+Because there are already heading levels 1 and 2 on the page, passing in `1`
+will produce an `h3`.
+
 #### OutputText
 
 This function takes a string of markdown code. This markdown is translated into

--- a/docgen/OutputHeading.ps1
+++ b/docgen/OutputHeading.ps1
@@ -1,0 +1,32 @@
+function MakeHeading {
+    [CmdletBinding()]
+    [OutputType([String])]
+    param(
+        [Parameter(Mandatory)]
+        [String] $TagName,
+        [Parameter(Mandatory)]
+        [String] $Content
+    )
+
+    return "<$TagName>$Content</$TagName>"
+}
+
+
+function OutputHeading {
+    [CmdletBinding()]
+    [OutputType([String])]
+    param(
+        [Parameter(Mandatory)]
+        [UInt32] $Level,
+        [Parameter(Mandatory)]
+        [String] $Text
+    )
+
+    switch ($Level) {
+        1 { return MakeHeading "h3" $Text }
+        2 { return MakeHeading "h4" $Text }
+        3 { return MakeHeading "h5" $Text }
+        4 { return MakeHeading "h6" $Text }
+        default { throw "Invalid heading level" }
+    }
+}

--- a/docgen/docgen.psd1
+++ b/docgen/docgen.psd1
@@ -14,11 +14,13 @@ NestedModules = @(
     "OutputExamplePage.ps1",
     "OutputText.ps1",
     "OutputCode.ps1",
+    "OutputHeading.ps1",
     "GeneralizeVersions.ps1",
     "ExesToTest.ps1")
 
 FunctionsToExport = @(
     "GenerateSite",
     "OutputText",
-    "OutputCode")
+    "OutputCode",
+    "OutputHeading")
 }

--- a/example-pages/errors/writeErrorFunction.psm1
+++ b/example-pages/errors/writeErrorFunction.psm1
@@ -11,6 +11,8 @@ function RunPage {
     [OutputType([String[]])]
     param()
 
+    OutputHeading 1 'Catching inside functions'
+
     OutputText @'
     When `$ErrorActionPreference` is `Stop`, `$PSCmdlet.WriteError` exits the
     current advanced function and throws. However, the exception it throws is
@@ -93,6 +95,8 @@ function RunPage {
             Write-Output "caught outside the function: $_"
         }
     }
+
+    OutputHeading 1 'Setting $?'
 
     OutputText @'
     The `WriteError` function differs from `Write-Error` in another way as


### PR DESCRIPTION
This helps to organize longer pages better.