### PR TITLE
Add TestOnlyMajorVersions option to buildSite.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The -PageName parameter to `buildSite.ps1` is shorthand for:
 }
 ```
 
+The -TestOnlyMajorVersions parameter to `buildSite.ps1` will only run major
+versions of PowerShell (i.e. 2.0, 5.1, 6.0.0, 7.0.0, etc.). This helps save a
+lot of time when building locally.
+
 ### View the site locally
 
 If you ran `buildSite.ps1`, the `webroot` directory will now contain the root

--- a/docgen/ExesToTest.ps1
+++ b/docgen/ExesToTest.ps1
@@ -12,7 +12,11 @@ function GetPowerShellExesToTest {
     [DirectoryInfo[]] $packages = Get-ChildItem $packageDir
     [String[]] $packageExes = $packages | ForEach-Object { "$($_.FullName)\pwsh.exe" }
 
-    return $windowsPowershellExes + $packageExes
+    if ($script:options.TestOnlyMajorVersions) {
+        return $windowsPowershellExes + ($packageExes | Where-Object { $_ -match "v[0-9]+\.0\.0" })
+    } else {
+        return $windowsPowershellExes + $packageExes
+    }
 }
 
 function RemoveBom {


### PR DESCRIPTION
This is useful for developing locally when running every single version
of PowerShell isn't crucial.