### PR TITLE
Add page about null-coalescing operator double evaluation

### DIFF
--- a/docgen/PageHelpers.ps1
+++ b/docgen/PageHelpers.ps1
@@ -1,8 +1,6 @@
 # Needed for types in classes below.
 using namespace System.IO
 
-[String] $script:versionsTestedHtml = ""
-
 function TitleToUrlPathSegment {
     [CmdletBinding()]
     [OutputType([String])]
@@ -81,13 +79,8 @@ function GetVersionsTestedHtml {
     [OutputType([String])]
     param()
 
-    if ($script:versionsTestedHtml.Length -eq 0) {
-        Write-Host "Caching list of tested versions..."
-        [SemanticVersion[]] $versionsTested = GetPowerShellExesToTest | ForEach-Object { GetExeVersion $_ } | Sort-Object
-        $script:versionsTestedHtml = ($versionsTested | ForEach-Object { "<span class=`"tested-version`">$_</span>" }) -join ", "
-    }
-
-    return $script:versionsTestedHtml
+    [SemanticVersion[]] $versionsTested = GetPowerShellExesToTest | ForEach-Object { $_.Item2 } | Sort-Object
+    return ($versionsTested | ForEach-Object { "<span class=`"tested-version`">$_</span>" }) -join ", "
 }
 
 function BuildSidebarHtml {

--- a/example-pages/basics/category.psm1
+++ b/example-pages/basics/category.psm1
@@ -1,0 +1,7 @@
+function GetTitle {
+    [CmdletBinding()]
+    [OutputType([String])]
+    param()
+
+    return 'Basics'
+}

--- a/example-pages/basics/nullCoalescingOperator.psm1
+++ b/example-pages/basics/nullCoalescingOperator.psm1
@@ -1,0 +1,51 @@
+function GetTitle {
+    [CmdletBinding()]
+    [OutputType([String])]
+    param()
+
+    return 'The null-coalescing operator'
+}
+
+function RunPage {
+    [CmdletBinding()]
+    [OutputType([String[]])]
+    param()
+
+    OutputHeading 1 'Double evaluation of first argument'
+
+    OutputText @'
+    The null-coalescing operator was introduced in PowerShell 7. In versions
+    7.0.0 and 7.0.1, however, the first argument of the operator is evaluated
+    twice if it's not null.
+
+    Notice that "ran func" is only printed out once even though the counter is
+    incremented twice. This is because the actual output of the function is
+    only used once, while any side effects such as incrementing a counter or
+    calling `Write-Host` would occur twice.
+'@
+
+    OutputCode -MinVersion 7 {
+        $global:counter = 0
+        function func {
+            $global:counter += 1
+            Write-Output 'ran func'
+        }
+
+        (func) ?? 'func returned null'
+        Write-Output "Counter: $global:counter"
+    }
+
+    OutputText @'
+    If the first argument is null, it's only evaluated once.
+'@
+
+    OutputCode -MinVersion 7 {
+        $global:counter = 0
+        function func {
+            $global:counter += 1
+        }
+
+        (func) ?? 'func returned null'
+        Write-Output "Counter: $global:counter"
+    }
+}


### PR DESCRIPTION
Since this operator was only introduced in PowerShell 7, I also added a
`MinVersion` parameter to `OutputCode` so that we weren't just
generating error output for versions less than 7.

We also now only get the version for a particular exe once. Before we
would require the version for each exe every time `OutputCode` ran,
which slowed down the build.