### PR TITLE
Fix responsiveness for Chrome

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,14 +6,14 @@ body {
     font-size: large;
     max-width: 100%;
 
-    margin-left: 2em;
-    margin-right: 2em;
+    margin-left: 2rem;
+    margin-right: 2rem;
 }
 
 #grid-container {
     display: grid;
 
-    grid-template-columns: fit-content(15rem) 1fr;
+    grid-template-columns: fit-content(15em) 1fr;
     grid-template-rows: max-content max-content 1fr;
     grid-template-areas:
         "header header"
@@ -23,7 +23,9 @@ body {
     column-gap: 3rem;
 }
 
-@media only screen and (width <= 40em) {
+/* Try to check if the screen width is less than the (very approximate) sum of
+ * all element max widths and paddings */
+@media only screen and (max-width: calc(2em + 15em + 3em + 40em + 2em)) {
     #grid-container {
         grid-template-columns: 100%;
         grid-template-rows: auto;


### PR DESCRIPTION
Chrome doesn't support the new range context syntax for media queries.

This change also switches around what's an em and what's a rem.