### PR TITLE
Change `GetExeVersion` to scrape the version from the directory path

### DIFF
--- a/docgen/docgen.psm1
+++ b/docgen/docgen.psm1
@@ -1,6 +1,7 @@
 using namespace System.Collections.Generic
 using namespace System.IO
 using namespace System.Management.Automation
+using namespace System.Text
 
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
This massively speeds up the dev inner loop, since you don't need to
wait for every executable to be run to get their versions.