### PR TITLE
Add sectioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,12 @@ function.
 Helper functions are available automatically in each page module's RunPage
 function.
 
-#### OutputHeading
+#### OutputSection
 
-This function takes a heading level (starting at 1) and content for the
-heading, and outputs a heading element.
-
-Because there are already heading levels 1 and 2 on the page, passing in `1`
-will produce an `h3`.
+This function takes the heading text and a script block of other commands that
+should output inside the section. It outputs a `<section>` element with an
+associated heading. Sections can be nested, and the heading level is
+automatically calculated.
 
 #### OutputText
 

--- a/docgen/OutputCode.ps1
+++ b/docgen/OutputCode.ps1
@@ -25,6 +25,10 @@ function OutputCode {
         [String] $MinVersion = "0"
     )
 
+    if ($script:buildingOutline) {
+        return
+    }
+
     [String] $codeAsString = $Code.ToString()
     [String] $formattedCode = FormatPageText $codeAsString
     [String] $codeHtml = "<pre class=`"code-view`"><code class=`"powershell`">" + $formattedCode + "</code></pre>"

--- a/docgen/OutputSection.ps1
+++ b/docgen/OutputSection.ps1
@@ -11,7 +11,6 @@ function MakeHeading {
     return "<$TagName>$Content</$TagName>"
 }
 
-
 function OutputHeading {
     [CmdletBinding()]
     [OutputType([String])]
@@ -29,4 +28,32 @@ function OutputHeading {
         4 { return MakeHeading "h6" $Text }
         default { throw "Invalid heading level" }
     }
+}
+
+function OutputSection {
+    [CmdletBinding()]
+    [OutputType([String])]
+    param(
+        [Parameter(Mandatory)]
+        [String] $HeadingText,
+        [Parameter(Mandatory)]
+        [ScriptBlock] $Code
+    )
+
+    if ($script:buildingOutline) {
+        $script:currentOutline += $HeadingText
+        & $Code
+        return
+    }
+
+    $script:sectionLevel += 1;
+    $html = '<section>'
+
+    $html += OutputHeading $script:sectionLevel $HeadingText
+    $html += (& $Code) -join "`n"
+
+    $html += '</section>'
+    $script:sectionLevel -= 1;
+
+    return $html
 }

--- a/docgen/OutputText.ps1
+++ b/docgen/OutputText.ps1
@@ -6,6 +6,10 @@ function OutputText {
         [String] $Text
     )
 
+    if ($script:buildingOutline) {
+        return
+    }
+
     [String] $formattedText = FormatPageText $Text
     [String] $rawHtml = (ConvertFrom-Markdown -InputObject $formattedText).Html
     return $rawHtml -replace "<p>", "<p class=`"content-text`">"

--- a/docgen/PageHelpers.ps1
+++ b/docgen/PageHelpers.ps1
@@ -67,7 +67,16 @@ class Page {
         return "/$categorySlug/$pageSlug.html"
     }
 
+    [Void] AddToOutline() {
+        $script:currentOutline = @()
+
+        $this.Module.RunPage() > $null
+
+        $script:outline[$this.GetTitle()] = $script:currentOutline
+    }
+
     [String] GetHtml([Page[]] $AllPages) {
+        [Byte] $script:sectionLevel = 0
         return OutputExamplePage $this $this.ModuleFileName $this.Module $AllPages
     }
 }
@@ -151,7 +160,7 @@ function BuildPageHtml {
     <!DOCTYPE html>
     <html lang="en-US">
         <head>
-            <meta charset="UTF-8" />
+            <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <title>$Title</title>
             <link rel="stylesheet" type="text/css" href="/css/style.css">
@@ -168,7 +177,9 @@ function BuildPageHtml {
                     <h1><a href="/">PowerShell live documentation</a></h1>
                 </header>
                 <main>
-                    $ContentHtml
+                    <article>
+                        $ContentHtml
+                    </article>
                 </main>
                 <aside id="versions-tested" aria-labelledby="versions-tested-heading">
                     <h2 id="versions-tested-heading">Versions tested</h2>

--- a/docgen/docgen.psd1
+++ b/docgen/docgen.psd1
@@ -14,7 +14,7 @@ NestedModules = @(
     "OutputExamplePage.ps1",
     "OutputText.ps1",
     "OutputCode.ps1",
-    "OutputHeading.ps1",
+    "OutputSection.ps1",
     "GeneralizeVersions.ps1",
     "ExesToTest.ps1")
 
@@ -22,5 +22,5 @@ FunctionsToExport = @(
     "GenerateSite",
     "OutputText",
     "OutputCode",
-    "OutputHeading")
+    "OutputSection")
 }

--- a/example-pages/basics/nullCoalescingOperator.psm1
+++ b/example-pages/basics/nullCoalescingOperator.psm1
@@ -11,41 +11,41 @@ function RunPage {
     [OutputType([String[]])]
     param()
 
-    OutputHeading 1 'Double evaluation of first argument'
+    OutputSection 'Double evaluation of first argument' {
+        OutputText @'
+        The null-coalescing operator was introduced in PowerShell 7. In
+        versions 7.0.0 and 7.0.1, however, the first argument of the operator
+        is evaluated twice if it's not null.
 
-    OutputText @'
-    The null-coalescing operator was introduced in PowerShell 7. In versions
-    7.0.0 and 7.0.1, however, the first argument of the operator is evaluated
-    twice if it's not null.
-
-    Notice that "ran func" is only printed out once even though the counter is
-    incremented twice. This is because the actual output of the function is
-    only used once, while any side effects such as incrementing a counter or
-    calling `Write-Host` would occur twice.
+        Notice that "ran func" is only printed out once even though the counter
+        is incremented twice. This is because the actual output of the function
+        is only used once, while any side effects such as incrementing a
+        counter or calling `Write-Host` would occur twice.
 '@
 
-    OutputCode -MinVersion 7 {
-        $global:counter = 0
-        function func {
-            $global:counter += 1
-            Write-Output 'ran func'
+        OutputCode -MinVersion 7 {
+            $global:counter = 0
+            function func {
+                $global:counter += 1
+                Write-Output 'ran func'
+            }
+
+            (func) ?? 'func returned null'
+            Write-Output "Counter: $global:counter"
         }
 
-        (func) ?? 'func returned null'
-        Write-Output "Counter: $global:counter"
-    }
-
-    OutputText @'
-    If the first argument is null, it's only evaluated once.
+        OutputText @'
+        If the first argument is null, it's only evaluated once.
 '@
 
-    OutputCode -MinVersion 7 {
-        $global:counter = 0
-        function func {
-            $global:counter += 1
-        }
+        OutputCode -MinVersion 7 {
+            $global:counter = 0
+            function func {
+                $global:counter += 1
+            }
 
-        (func) ?? 'func returned null'
-        Write-Output "Counter: $global:counter"
+            (func) ?? 'func returned null'
+            Write-Output "Counter: $global:counter"
+        }
     }
 }

--- a/example-pages/classes/methodStdio.psm1
+++ b/example-pages/classes/methodStdio.psm1
@@ -22,58 +22,58 @@ function RunPage {
     exceptions.
 '@
 
-    OutputHeading 1 'Stdout'
-
-    OutputText @'
-    Stdout is never output to the console, no matter the return type of the
-    method.
+    OutputSection 'Stdout' {
+        OutputText @'
+        Stdout is never output to the console, no matter the return type of the
+        method.
 '@
 
-    OutputCode -MinVersion 5 {
-        class C {
-            [String] Func1() {
-                Write-Output 'Func1: writing string to stdout'
-                return 'Func1: returning a string'
+        OutputCode -MinVersion 5 {
+            class C {
+                [String] Func1() {
+                    Write-Output 'Func1: writing string to stdout'
+                    return 'Func1: returning a string'
+                }
+
+                [String] Func2() {
+                    cmd /c 'echo Func2: writing string to stdout'
+                    return 'Func2: returning a string'
+                }
+
+                [UInt32] Func3() {
+                    Write-Output 'Func3: writing string to stdout'
+                    return 3
+                }
+
+                [UInt32] Func4() {
+                    cmd /c 'echo Func4: writing string to stdout'
+                    return 4
+                }
+
+                [Void] Func5() {
+                    Write-Output 'Func5: writing string to stdout'
+                }
+
+                [Void] Func6() {
+                    cmd /c 'echo Func6: writing string to stdout'
+                }
             }
 
-            [String] Func2() {
-                cmd /c 'echo Func2: writing string to stdout'
-                return 'Func2: returning a string'
-            }
-
-            [UInt32] Func3() {
-                Write-Output 'Func3: writing string to stdout'
-                return 3
-            }
-
-            [UInt32] Func4() {
-                cmd /c 'echo Func4: writing string to stdout'
-                return 4
-            }
-
-            [Void] Func5() {
-                Write-Output 'Func5: writing string to stdout'
-            }
-
-            [Void] Func6() {
-                cmd /c 'echo Func6: writing string to stdout'
-            }
+            $c = [C]::new()
+            $c.Func1()
+            $c.Func2()
+            $c.Func3()
+            $c.Func4()
+            $c.Func5()
+            $c.Func6()
         }
-
-        $c = [C]::new()
-        $c.Func1()
-        $c.Func2()
-        $c.Func3()
-        $c.Func4()
-        $c.Func5()
-        $c.Func6()
     }
 
-    OutputHeading 1 'Stderr'
+    OutputSection 'Stderr' {
+        OutputText 'Coming soon...'
+    }
 
-    OutputText 'Coming soon...'
-
-    OutputHeading 1 'Stdin'
-
-    OutputText 'TODO'
+    OutputSection 'Stdin' {
+        OutputText 'TODO'
+    }
 }

--- a/example-pages/errors/writeErrorFunction.psm1
+++ b/example-pages/errors/writeErrorFunction.psm1
@@ -11,142 +11,145 @@ function RunPage {
     [OutputType([String[]])]
     param()
 
-    OutputHeading 1 'Catching inside functions'
+    OutputSection 'Catching inside functions' {
+        OutputText @'
+        When `$ErrorActionPreference` is `Stop`, `$PSCmdlet.WriteError` exits
+        the current advanced function and throws. However, the exception it
+        throws is not catchable from within the advanced function.
 
-    OutputText @'
-    When `$ErrorActionPreference` is `Stop`, `$PSCmdlet.WriteError` exits the
-    current advanced function and throws. However, the exception it throws is
-    not catchable from within the advanced function.
-
-    It's worth noting that in PowerShell 2, the exception is caught both inside
-    the function and outside the function. Inside the function we catch a "The
-    pipeline has been stopped." error, and then continue execution within the
-    function. When the function exits, we then throw the original exception.
+        It's worth noting that in PowerShell 2, the exception is caught both
+        inside the function and outside the function. Inside the function we
+        catch a "The pipeline has been stopped." error, and then continue
+        execution within the function. When the function exits, we then throw
+        the original exception.
 '@
 
-    OutputCode {
-        function TestWriteErrorFunction {
-            [CmdletBinding()]
-            param()
+        OutputCode {
+            function TestWriteErrorFunction {
+                [CmdletBinding()]
+                param()
 
-            $local:ErrorActionPreference = "Stop"
-            try {
-                $PSCmdlet.WriteError((NewErrorRecord "error in try"))
-            } catch {
-                Write-Output "caught inside the function: $_"
+                $local:ErrorActionPreference = "Stop"
+                try {
+                    $PSCmdlet.WriteError((NewErrorRecord "error in try"))
+                } catch {
+                    Write-Output "caught inside the function: $_"
+                }
+
+                Write-Output "after the try-catch"
             }
 
-            Write-Output "after the try-catch"
+            try {
+                TestWriteErrorFunction
+            } catch {
+                Write-Output "caught outside the function: $_"
+            }
         }
 
-        try {
-            TestWriteErrorFunction
-        } catch {
-            Write-Output "caught outside the function: $_"
+        OutputText @'
+        `Write-Error`, on the other hand, is catchable inside the function, for
+        both advanced and basic functions.
+'@
+
+        OutputCode {
+            function TestWriteErrorCmdletAdvanced {
+                [CmdletBinding()]
+                param()
+
+                $local:ErrorActionPreference = "Stop"
+                try {
+                    Write-Error "error in try"
+                } catch {
+                    Write-Output "caught inside the function: $_"
+                }
+
+                Write-Output "after the try-catch"
+            }
+
+            function TestWriteErrorCmdletBasic {
+                param()
+
+                $local:ErrorActionPreference = "Stop"
+                try {
+                    Write-Error "error in try"
+                } catch {
+                    Write-Output "caught inside the function: $_"
+                }
+
+                Write-Output "after the try-catch"
+            }
+
+            Write-Output "testing advanced function"
+            try {
+                TestWriteErrorCmdletAdvanced
+            } catch {
+                Write-Output "caught outside the function: $_"
+            }
+
+            Write-Output ""
+
+            Write-Output "testing basic function"
+            try {
+                TestWriteErrorCmdletBasic
+            } catch {
+                Write-Output "caught outside the function: $_"
+            }
         }
     }
 
-    OutputText @'
-    `Write-Error`, on the other hand, is catchable inside the function, for
-    both advanced and basic functions.
+    OutputSection 'Setting $?' {
+        OutputText @'
+        The `WriteError` function differs from `Write-Error` in another way as
+        well. When used inside a function, either advanced or basic,
+        `Write-Error` will not set `$?` to false after the function exits.
+        `WriteError`, on the other hand, will set `$?` to false after the
+        function exits.
+
+        Interestingly, `Write-Error` will set `$?` to false within its own
+        scope. `WriteError`, however, won't touch `$?` until the function
+        exits.
 '@
 
-    OutputCode {
-        function TestWriteErrorCmdletAdvanced {
-            [CmdletBinding()]
-            param()
+        OutputCode {
+            function AdvancedWriteErrorCmdlet {
+                [CmdletBinding()]
+                param()
 
-            $local:ErrorActionPreference = "Stop"
-            try {
-                Write-Error "error in try"
-            } catch {
-                Write-Output "caught inside the function: $_"
+                $local:ErrorActionPreference = "SilentlyContinue"
+                Write-Error "an error"
+
+                Write-Output "Inside advanced function calling Write-Error status: $?"
             }
 
-            Write-Output "after the try-catch"
-        }
+            function BasicWriteErrorCmdlet {
+                param()
 
-        function TestWriteErrorCmdletBasic {
-            param()
+                $local:ErrorActionPreference = "SilentlyContinue"
+                Write-Error "an error"
 
-            $local:ErrorActionPreference = "Stop"
-            try {
-                Write-Error "error in try"
-            } catch {
-                Write-Output "caught inside the function: $_"
+                Write-Output "Inside basic function calling Write-Error status: $?"
             }
 
-            Write-Output "after the try-catch"
+            function AdvancedWriteErrorFunction {
+                [CmdletBinding()]
+                param()
+
+                $local:ErrorActionPreference = "SilentlyContinue"
+                $PSCmdlet.WriteError((NewErrorRecord "an error"))
+
+                Write-Output "Inside advanced function calling `$PSCmdlet.WriteError status: $?"
+            }
+
+            AdvancedWriteErrorCmdlet
+            Write-Output "Advanced function calling Write-Error exited with: $?"
+            Write-Output ""
+
+            BasicWriteErrorCmdlet
+            Write-Output "Basic function calling Write-Error exited with: $?"
+            Write-Output ""
+
+            AdvancedWriteErrorFunction
+            Write-Output "Advanced function calling `$PSCmdlet.WriteError exited with: $?"
         }
-
-        Write-Output "testing advanced function"
-        try {
-            TestWriteErrorCmdletAdvanced
-        } catch {
-            Write-Output "caught outside the function: $_"
-        }
-
-        Write-Output ""
-
-        Write-Output "testing basic function"
-        try {
-            TestWriteErrorCmdletBasic
-        } catch {
-            Write-Output "caught outside the function: $_"
-        }
-    }
-
-    OutputHeading 1 'Setting $?'
-
-    OutputText @'
-    The `WriteError` function differs from `Write-Error` in another way as
-    well. When used inside a function, either advanced or basic, `Write-Error`
-    will not set `$?` to false after the function exits. `WriteError`, on the
-    other hand, will set `$?` to false after the function exits.
-
-    Interestingly, `Write-Error` will set `$?` to false within its own scope.
-    `WriteError`, however, won't touch `$?` until the function exits.
-'@
-
-    OutputCode {
-        function AdvancedWriteErrorCmdlet {
-            [CmdletBinding()]
-            param()
-
-            $local:ErrorActionPreference = "SilentlyContinue"
-            Write-Error "an error"
-
-            Write-Output "Inside advanced function calling Write-Error status: $?"
-        }
-
-        function BasicWriteErrorCmdlet {
-            param()
-
-            $local:ErrorActionPreference = "SilentlyContinue"
-            Write-Error "an error"
-
-            Write-Output "Inside basic function calling Write-Error status: $?"
-        }
-
-        function AdvancedWriteErrorFunction {
-            [CmdletBinding()]
-            param()
-
-            $local:ErrorActionPreference = "SilentlyContinue"
-            $PSCmdlet.WriteError((NewErrorRecord "an error"))
-
-            Write-Output "Inside advanced function calling `$PSCmdlet.WriteError status: $?"
-        }
-
-        AdvancedWriteErrorCmdlet
-        Write-Output "Advanced function calling Write-Error exited with: $?"
-        Write-Output ""
-
-        BasicWriteErrorCmdlet
-        Write-Output "Basic function calling Write-Error exited with: $?"
-        Write-Output ""
-
-        AdvancedWriteErrorFunction
-        Write-Output "Advanced function calling `$PSCmdlet.WriteError exited with: $?"
     }
 }


### PR DESCRIPTION
This puts each page into an <article> wrapper and wraps page sections in
<section> elements. The OutputHeading command is replaced with
OutputSection, which automatically detects heading level.

An outline was also generated from the section information. This can be
used for special link syntax later.