### PR TITLE
Replace classes with PSCustomObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ This will generate the files for the site, using all the PowerShell versions in
 If you don't want to build the entire site during development, you can specify
 a script block to the `buildSite.ps1` -PageFilter parameter. The script block
 will be passed two arguments: a list of all example pages that can be built and
-the current page the filter is running on. Pages are instances of `Page` as
-defined in `PageHelpers.ps1`. If the script block returns true, the page will
-be generated.
+the current page the filter is running on. Pages are instances of
+`PSCustomObject` with type name "Page" as defined in `PageHelpers.ps1`. If the
+script block returns true, the page will be generated.
 
 For example, if you only wanted to build the page at
 "/errors/exit-status-variable-$-question-mark.html", you could do:
 
 ```powershell
 .\buildSite.ps1 -PageFilter {
-    param([Page[]] $AllPages, [Page] $PageToCheck)
+    param($AllPages, $PageToCheck)
     return $PageToCheck.GetLinkPath() -eq '/errors/exit-status-variable-$-question-mark.html'
 }
 ```
@@ -89,9 +89,18 @@ The -PageNames parameter to `buildSite.ps1` is shorthand for:
 
 ```powershell
 .\buildSite.ps1 -PageFilter {
-    param([Page[]] $AllPages, [Page] $PageToCheck)
+    param(
+        [Parameter(Mandatory)]
+        [PSTypeName('Page')]
+        [PSCustomObject[]] $AllPages,
+
+        [Parameter(Mandatory)]
+        [PSTypeName('Page')]
+        [PSCustomObject] $PageToCheck
+    )
+
     [String] $title = $PageToCheck.GetTitle()
-    <page name list> | ForEach-Object `
+    $PageNames | ForEach-Object `
         { [Boolean] $b = $false } `
         { $b = $b -or ($title -like $_) } `
         { $b }

--- a/docgen/GenerateSite.ps1
+++ b/docgen/GenerateSite.ps1
@@ -35,9 +35,9 @@ function GenerateSite {
     Remove-Item $webrootPath -Recurse -Force -ErrorAction "SilentlyContinue"
     mkdir $webrootPath > $null
 
-    [Page[]] $pages = Get-ChildItem "$projectRoot\example-pages\*.psm1" -Exclude "category.psm1" -Recurse |`
-        ForEach-Object { [Page]::new($_) }
-    [Page[]] $filteredPages = $pages | Where-Object { Invoke-Command $PageFilter -Args $pages, $_ }
+    [PSCustomObject[]] $pages = Get-ChildItem "$projectRoot\example-pages\*.psm1" -Exclude "category.psm1" -Recurse |`
+        ForEach-Object { NewPage $_ }
+    [PSCustomObject[]] $filteredPages = $pages | Where-Object { Invoke-Command $PageFilter -Args $pages, $_ }
 
     # Build the page outlines.
     [Hashtable] $script:outline = @{}

--- a/docgen/OutputExamplePage.ps1
+++ b/docgen/OutputExamplePage.ps1
@@ -3,13 +3,18 @@ function OutputExamplePage {
     [OutputType([String])]
     param(
         [Parameter(Mandatory)]
-        [Page] $Page,
+        [PSTypeName('Page')]
+        [PSCustomObject] $Page,
+
         [Parameter(Mandatory)]
         [String] $pageModuleFileName,
+
         [Parameter(Mandatory)]
         [PSCustomObject] $PageModule,
+
         [Parameter(Mandatory)]
-        [Page[]] $Pages
+        [PSTypeName('Page')]
+        [PSCustomObject[]] $Pages
     )
 
     [String] $title = $PageModule.GetTitle()

--- a/docgen/OutputHomePage.ps1
+++ b/docgen/OutputHomePage.ps1
@@ -3,7 +3,8 @@ function OutputHomePage {
     [OutputType([String])]
     param(
         [Parameter(Mandatory)]
-        [Page[]] $Pages
+        [PSTypeName('Page')]
+        [PSCustomObject[]] $Pages
     )
 
     [String] $mainPageContent = OutputText @'

--- a/docgen/Util.ps1
+++ b/docgen/Util.ps1
@@ -1,3 +1,19 @@
+function AddScriptMethod {
+    [CmdletBinding()]
+    [OutputType([Void])]
+    param(
+        [Parameter(Mandatory)]
+        [String] $TypeName,
+        [Parameter(Mandatory)]
+        [String] $MethodName,
+        [Parameter(Mandatory)]
+        [ScriptBlock] $Definition
+    )
+
+    Update-TypeData -TypeName $TypeName -MemberName $MethodName `
+        -MemberType ScriptMethod -Value $Definition -Force
+}
+
 function GetIndent {
     [CmdletBinding()]
     [OutputType([Byte])]

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -1,20 +1,12 @@
 Push-Location $PSScriptRoot
 try {
-    # Invoke-Pester needs to run in its own powershell session because
-    # otherwise classes in modules like docgen get cached and can't be changed
-    # during development. Import-Module -Force doesn't work with classes :(
-    pwsh -c {
-        Import-Module pester -Force
-        [PesterConfiguration] $config = [PesterConfiguration]::Default
+    Import-Module pester -Force
+    [PesterConfiguration] $config = [PesterConfiguration]::Default
 
-        # Exit with non-zero exit code when the test run fails.
-        $config.Run.Exit = $true
+    # Exit with non-zero exit code when the test run fails.
+    $config.Run.Exit = $true
 
-        Invoke-Pester -Configuration $config
-    }
-    [Int32] $exitCode = $LASTEXITCODE
+    Invoke-Pester -Configuration $config
 } finally {
     Pop-Location
 }
-
-exit $exitCode

--- a/tests/GeneralizeVersions.Tests.ps1
+++ b/tests/GeneralizeVersions.Tests.ps1
@@ -45,17 +45,17 @@ function global:V {
 Describe "VersionTree" {
     InModuleScope docgen {
         It "starts out as empty" {
-            [VersionTree]::new().ToString() | Should -Be "root"
+            (NewVersionTree).ToString() | Should -Be "root"
         }
 
         It "can add a single version" {
-            [VersionTree] $tree = [VersionTree]::new()
+            [PSCustomObject] $tree = NewVersionTree
             $tree.Add((V 1.2.3))
             $tree.ToString() | Should -Be "(root (1 (2 3)))"
         }
 
         It "can add multiple versions" {
-            [VersionTree] $tree = [VersionTree]::new()
+            [PSCustomObject] $tree = NewVersionTree
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }
@@ -64,7 +64,7 @@ Describe "VersionTree" {
         }
 
         It "can mark a single version" {
-            [VersionTree] $tree = [VersionTree]::new()
+            [PSCustomObject] $tree = NewVersionTree
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }
@@ -75,7 +75,7 @@ Describe "VersionTree" {
         }
 
         It "can mark multiple versions" {
-            [VersionTree] $tree = [VersionTree]::new()
+            [PSCustomObject] $tree = NewVersionTree
             foreach ($version in $allVersions) {
                 $tree.Add($version)
             }


### PR DESCRIPTION
The fact that you can't reload classes in a given session was making it
kinda difficult to debug. Tests and builds needed to run in their own
sessions, and as a result the $error variable wasn't available to figure
out exactly where an error occurred.

While PSCustomObject isn't as well integrated into the type system as
classes are, I still think it's the best choice going forward.