### PR TITLE
Only remove contents of webroot before build, rather than directory itself

### DIFF
--- a/docgen/GenerateSite.ps1
+++ b/docgen/GenerateSite.ps1
@@ -32,8 +32,10 @@ function GenerateSite {
     [String] $projectRoot = "$PSScriptRoot\.."
 
     [String] $webrootPath = "$projectRoot\webroot"
-    Remove-Item $webrootPath -Recurse -Force -ErrorAction "SilentlyContinue"
-    mkdir $webrootPath > $null
+    if (-not (Test-Path $webrootPath)) {
+        mkdir $webrootPath > $null
+    }
+    Remove-Item "$webrootPath\*" -Recurse -Force -ErrorAction "SilentlyContinue"
 
     [PSCustomObject[]] $pages = Get-ChildItem "$projectRoot\example-pages\*.psm1" -Exclude "category.psm1" -Recurse |`
         ForEach-Object { NewPage $_ }


### PR DESCRIPTION
Previously, if we had a static file server like Python's http.server
running in the webroot, we'd have to kill it before and build and
restart it once the build was over, since it was locking the webroot and
we'd be unable to delete that directory. Now that we're just deleting
the webroot contents, the file server doesn't have to be killed.