### PR TITLE
Get rid of category names in page URLs

### DIFF
--- a/docgen/GenerateSite.ps1
+++ b/docgen/GenerateSite.ps1
@@ -56,6 +56,11 @@ function GenerateSite {
     [String] $homePageHtml = OutputHomePage $filteredPages
     WriteHtmlFile 'index.html' $homePageHtml
 
+    # Write out the redirects.
+    [PSCustomObject[]] $redirects = GetRedirects "$projectRoot\example-pages\redirects"
+    $redirects | `
+        ForEach-Object { WriteHtmlFile $_.FromUrl $_.GetHtml() }
+
     # Copy static assets to the webroot.
     Copy-Item "$projectRoot\static\*" $webrootPath -Recurse
 }

--- a/example-pages/redirects
+++ b/example-pages/redirects
@@ -1,0 +1,6 @@
+/basics/the-null-coalescing-operator           /the-null-coalescing-operator
+/basics/pscustomobject                         /pscustomobject
+/basics/the-stderr-stream                      /the-stderr-stream
+/classes/method-stdio                          /method-stdio
+/errors/exit-status-variable-$-question-mark   /exit-status-variable-$-question-mark
+/errors/the-writeerror-function                /the-writeerror-function


### PR DESCRIPTION
There isn't really much risk of page URLs conflicting without the
category name. Plus, this method allows more flexibility to move pages
between categories or even get rid of the concept of categories
altogether.

This change also introduces a redirects file which is used to generate
placeholder HTML pages for pages that no longer exist. These pages use a
meta tag to redirect to the new URL, which is a server-independent way
of doing redirection. This is necessary, since links might exist to the
old pages with the category URLs (no matter how unlikely).