### PR TITLE
Use Netlify redirects rather than home-spun redirect files

### DIFF
--- a/docgen/GenerateSite.ps1
+++ b/docgen/GenerateSite.ps1
@@ -56,11 +56,6 @@ function GenerateSite {
     [String] $homePageHtml = OutputHomePage $filteredPages
     WriteHtmlFile 'index.html' $homePageHtml
 
-    # Write out the redirects.
-    [PSCustomObject[]] $redirects = GetRedirects "$projectRoot\example-pages\redirects"
-    $redirects | `
-        ForEach-Object { WriteHtmlFile $_.FromUrl $_.GetHtml() }
-
     # Copy static assets to the webroot.
     Copy-Item "$projectRoot\static\*" $webrootPath -Recurse
 }

--- a/docgen/PageHelpers.ps1
+++ b/docgen/PageHelpers.ps1
@@ -112,62 +112,6 @@ AddScriptMethod Page GetHtml {
 
 #endregion
 
-#region Redirect
-
-function GetRedirects {
-    [CmdletBinding()]
-    [OutputType([PSCustomObject[]])]
-    param(
-        [Parameter(Mandatory)]
-        [String] $RedirectsFilePath
-    )
-
-    return Get-Content $RedirectsFilePath | ForEach-Object {
-        [String] $line = $_
-        [String[]] $tokens = $line.Split()
-        return NewRedirect $tokens[0] $tokens[-1]
-    }
-}
-
-function NewRedirect {
-    [CmdletBinding()]
-    [OutputType([PSCustomObject])]
-    param(
-        [Parameter(Mandatory)]
-        [String] $FromUrl,
-
-        [Parameter(Mandatory)]
-        [String] $ToUrl
-    )
-
-    return [PSCustomObject]@{
-        PSTypeName = 'Redirect'
-        FromUrl = "$FromUrl.html"
-        ToUrl = "$ToUrl.html"
-    }
-}
-
-AddScriptMethod Redirect GetHtml {
-    [CmdletBinding()]
-    [OutputType([String])]
-    param()
-
-    return @"
-    <!DOCTYPE html>
-    <html lang="en-US">
-        <head>
-            <meta charset="UTF-8">
-            <meta http-equiv="refresh" content="0; url='$($this.ToUrl)'" />
-        </head>
-        <body>
-            <p>Redirecting to <a href="$($this.ToUrl)">$($this.ToUrl)</a>...</p>
-        </body>
-    </html>
-"@
-}
-
-#endregion
-
 function GetVersionsTestedHtml {
     [CmdletBinding()]
     [OutputType([String])]

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,4 @@
+# Redirects from old pages using categories.
 /basics/the-null-coalescing-operator           /the-null-coalescing-operator
 /basics/pscustomobject                         /pscustomobject
 /basics/the-stderr-stream                      /the-stderr-stream


### PR DESCRIPTION
The old method of redirects didn't work with Netlify pretty URLs. This
method only works on Netlify, but if we move to a new hosting provider
we can deal with that then.

Note that I think it's worth not relying on Netlify pretty URLs in
general and writing all links without .html extensions to start with.
However, the Python static file server I'm using for testing doesn't
allow this. It's something to think about for the future.